### PR TITLE
Skip redundant modalias calls to modprobe

### DIFF
--- a/c_src/uevent.c
+++ b/c_src/uevent.c
@@ -78,6 +78,12 @@ static void run_modprobes()
 
 static void queue_modprobe(char *modalias)
 {
+    // Optimization: Skip consecutive duplicate modalias strings since some
+    // devices have several adjacent entries serviced by the same alias.
+    if (modprobe_queue_n > 2 &&
+        strcmp(modprobe_queue_argv[modprobe_queue_n - 1], modalias) == 0)
+        return;
+
     size_t modalias_len = strlen(modalias) + 1;
     if (modprobe_queue_index + modalias_len > sizeof(modprobe_queue_buffer)) {
         run_modprobes();


### PR DESCRIPTION
While watching calls to modprobe, I saw that some devices would report
the same modalias many times in a row - sometimes 10 times. This is
useless since one modprobe per modalias is enough. Trimming this is
trivial and reduces the number of times modprobe needs to be run.
