### PR TITLE
Report stats via NervesUEvent.stats/0

### DIFF
--- a/c_src/uevent.c
+++ b/c_src/uevent.c
@@ -26,13 +26,42 @@
 #include <ei.h>
 
 static int run_modprobe = 0;
-static int modprobe_queue_n;
-static int modprobe_queue_index;
+static uint32_t modprobe_queue_n;
+static uint32_t modprobe_queue_index;
 // Experimentation showed that batches max out around 18 modprobe calls and
 // require a max ~700 bytes of buffer. These shouldn't overflow in practice,
 // but are still checked below.
 static char modprobe_queue_buffer[1024];
 static char *modprobe_queue_argv[32];
+
+// Cumulative counters reported to Elixir
+struct stats {
+    uint32_t uevents_received;
+    // Kernel buffer-overflow incidents (ENOBUFS). This indicates lost events
+    // and is a serious error since it's unrecoverable without restarting.
+    uint32_t uevents_dropped;
+
+    uint32_t modprobes_called;
+    uint32_t modaliases_queued;
+    uint32_t modaliases_dropped;
+    uint32_t modprobe_fork_failures;
+
+    // High-water marks for the modprobe queue for tuning
+    uint32_t peak_queue_n;
+    uint32_t peak_queue_bytes;
+
+    // Per-action tallies
+    uint32_t action_add;
+    uint32_t action_change;
+    uint32_t action_remove;
+    uint32_t action_move;
+    uint32_t action_bind;
+    uint32_t action_unbind;
+    uint32_t action_other;
+};
+
+static struct stats stats;
+static int stats_dirty = 0;
 
 static void reset_modprobe_queue()
 {
@@ -72,6 +101,9 @@ static void run_modprobes()
             rc = waitpid(pid, &status, 0);
         } while (rc < 0 && errno == EINTR);
 
+        stats.modprobes_called++;
+        stats_dirty = 1;
+
         // Ignore errors.
         reset_modprobe_queue();
     }
@@ -96,6 +128,12 @@ static void queue_modprobe(char *modalias)
     strcpy(p, modalias);
     modprobe_queue_index += modalias_len;
     modprobe_queue_n++;
+    stats.modaliases_queued++;
+    if (modprobe_queue_n > stats.peak_queue_n)
+        stats.peak_queue_n = modprobe_queue_n;
+    if (modprobe_queue_index > stats.peak_queue_bytes)
+        stats.peak_queue_bytes = modprobe_queue_index;
+    stats_dirty = 1;
 }
 
 static void erlcmd_write_header_len(char *response, size_t len)
@@ -207,10 +245,15 @@ static int nl_uevent_process_one(struct mnl_socket *nl_uevent, char *resp)
             // useful when debugging if messages are suspected to have
             // been dropped.
             // warnx("mnl_socket_recvfrom: netlink messages dropped");
+            stats.uevents_dropped++;
+            stats_dirty = 1;
             return -1;
         }
         err(EXIT_FAILURE, "mnl_socket_recvfrom");
     }
+
+    stats.uevents_received++;
+    stats_dirty = 1;
 
     char *str = nlbuf;
     char *str_end = str + bytecount;
@@ -239,6 +282,14 @@ static int nl_uevent_process_one(struct mnl_socket *nl_uevent, char *resp)
     // action
     const char *action = str;
     ei_encode_atom(resp, &resp_index, str);
+
+    if (strcmp(action, "add") == 0) stats.action_add++;
+    else if (strcmp(action, "change") == 0) stats.action_change++;
+    else if (strcmp(action, "remove") == 0) stats.action_remove++;
+    else if (strcmp(action, "move") == 0) stats.action_move++;
+    else if (strcmp(action, "bind") == 0) stats.action_bind++;
+    else if (strcmp(action, "unbind") == 0) stats.action_unbind++;
+    else stats.action_other++;
 
     // devpath - filter anything that's not under "/devices"
     str = atsign + 1;
@@ -289,6 +340,55 @@ static int nl_uevent_process_one(struct mnl_socket *nl_uevent, char *resp)
     }
     erlcmd_write_header_len(resp, resp_index);
     return resp_index;
+}
+
+static void send_stats()
+{
+    // 1 KB easily covers the encoded map — 8 scalars plus a nested 7-entry
+    // action submap, each value a u32 and each key a short atom.
+    char resp[1024];
+    int resp_index = sizeof(uint16_t); // skip over the 2-byte length prefix
+    ei_encode_version(resp, &resp_index);
+    ei_encode_tuple_header(resp, &resp_index, 2);
+    ei_encode_atom(resp, &resp_index, "stats");
+    ei_encode_map_header(resp, &resp_index, 9);
+
+    ei_encode_atom(resp, &resp_index, "uevents_received");
+    ei_encode_ulong(resp, &resp_index, stats.uevents_received);
+    ei_encode_atom(resp, &resp_index, "uevents_dropped");
+    ei_encode_ulong(resp, &resp_index, stats.uevents_dropped);
+    ei_encode_atom(resp, &resp_index, "modprobes_called");
+    ei_encode_ulong(resp, &resp_index, stats.modprobes_called);
+    ei_encode_atom(resp, &resp_index, "modaliases_queued");
+    ei_encode_ulong(resp, &resp_index, stats.modaliases_queued);
+    ei_encode_atom(resp, &resp_index, "modaliases_dropped");
+    ei_encode_ulong(resp, &resp_index, stats.modaliases_dropped);
+    ei_encode_atom(resp, &resp_index, "modprobe_fork_failures");
+    ei_encode_ulong(resp, &resp_index, stats.modprobe_fork_failures);
+    ei_encode_atom(resp, &resp_index, "peak_queue_n");
+    ei_encode_ulong(resp, &resp_index, stats.peak_queue_n);
+    ei_encode_atom(resp, &resp_index, "peak_queue_bytes");
+    ei_encode_ulong(resp, &resp_index, stats.peak_queue_bytes);
+
+    ei_encode_atom(resp, &resp_index, "actions");
+    ei_encode_map_header(resp, &resp_index, 7);
+    ei_encode_atom(resp, &resp_index, "add");
+    ei_encode_ulong(resp, &resp_index, stats.action_add);
+    ei_encode_atom(resp, &resp_index, "change");
+    ei_encode_ulong(resp, &resp_index, stats.action_change);
+    ei_encode_atom(resp, &resp_index, "remove");
+    ei_encode_ulong(resp, &resp_index, stats.action_remove);
+    ei_encode_atom(resp, &resp_index, "move");
+    ei_encode_ulong(resp, &resp_index, stats.action_move);
+    ei_encode_atom(resp, &resp_index, "bind");
+    ei_encode_ulong(resp, &resp_index, stats.action_bind);
+    ei_encode_atom(resp, &resp_index, "unbind");
+    ei_encode_ulong(resp, &resp_index, stats.action_unbind);
+    ei_encode_atom(resp, &resp_index, "other");
+    ei_encode_ulong(resp, &resp_index, stats.action_other);
+
+    erlcmd_write_header_len(resp, resp_index);
+    write_all(resp, resp_index);
 }
 
 static void nl_uevent_process_all(struct mnl_socket *nl_uevent)
@@ -424,13 +524,20 @@ int main(int argc, char *argv[])
         fdset[1].events = POLLIN;
         fdset[1].revents = 0;
 
-        int rc = poll(fdset, 2, -1);
+        int timeout = stats_dirty ? 5000 : -1;
+        int rc = poll(fdset, 2, timeout);
         if (rc < 0) {
             // Retry if EINTR
             if (errno == EINTR)
                 continue;
 
             err(EXIT_FAILURE, "poll");
+        }
+
+        if (rc == 0 && stats_dirty) {
+            send_stats();
+            stats_dirty = 0;
+            continue;
         }
 
         if (fdset[0].revents & (POLLIN | POLLHUP))

--- a/lib/nerves_uevent.ex
+++ b/lib/nerves_uevent.ex
@@ -55,4 +55,28 @@ defmodule NervesUEvent do
   """
   @spec subscribe(PropertyTable.pattern()) :: :ok
   def subscribe(property), do: PropertyTable.subscribe(NervesUEvent, property)
+
+  @doc """
+  Return counters collected by the uevent port.
+
+  Top-level keys:
+
+    * `:uevents_received` — netlink messages successfully read
+    * `:uevents_dropped` — ENOBUFS incidents (kernel dropped one or more messages)
+    * `:modprobes_called` — modprobe child processes launched
+    * `:modaliases_queued` — modaliases queued for modprobe
+    * `:modaliases_dropped` — modaliases dropped because the queue was full
+      while a modprobe was already in flight
+    * `:modprobe_fork_failures` — `fork()` failures when launching modprobe
+    * `:peak_queue_n` — high-water mark for queued modalias count
+    * `:peak_queue_bytes` — high-water mark for the modalias byte buffer
+    * `:actions` — nested map of `add | change | remove | move | bind | unbind | other`
+      counts, matching the uevent ACTION field
+
+  Counters are cumulative since the port started and are 32-bit. The port
+  pushes snapshots after ~5 s of netlink idle, so values may lag during a
+  uevent burst.
+  """
+  @spec stats() :: NervesUEvent.UEvent.stats()
+  def stats(), do: NervesUEvent.UEvent.stats()
 end

--- a/lib/nerves_uevent/uevent.ex
+++ b/lib/nerves_uevent/uevent.ex
@@ -9,6 +9,28 @@ defmodule NervesUEvent.UEvent do
 
   @type option() :: {:autoload_modules, boolean()}
 
+  @type action_stats() :: %{
+          add: non_neg_integer(),
+          change: non_neg_integer(),
+          remove: non_neg_integer(),
+          move: non_neg_integer(),
+          bind: non_neg_integer(),
+          unbind: non_neg_integer(),
+          other: non_neg_integer()
+        }
+
+  @type stats() :: %{
+          uevents_received: non_neg_integer(),
+          uevents_dropped: non_neg_integer(),
+          modprobes_called: non_neg_integer(),
+          modaliases_queued: non_neg_integer(),
+          modaliases_dropped: non_neg_integer(),
+          modprobe_fork_failures: non_neg_integer(),
+          peak_queue_n: non_neg_integer(),
+          peak_queue_bytes: non_neg_integer(),
+          actions: action_stats()
+        }
+
   @spec start_link([option()]) :: GenServer.on_start()
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -22,6 +44,15 @@ defmodule NervesUEvent.UEvent do
     executable = Application.app_dir(:nerves_uevent, ["priv", "uevent"])
     File.exists?(executable)
   end
+
+  @doc """
+  Return the most recent counters reported by the C port.
+
+  The port pushes an updated snapshot after ~5 s of netlink idle, so the
+  returned map may lag real counts during a uevent burst.
+  """
+  @spec stats() :: stats()
+  def stats(), do: GenServer.call(__MODULE__, :stats)
 
   @impl GenServer
   def init(opts) do
@@ -39,43 +70,80 @@ defmodule NervesUEvent.UEvent do
         :exit_status
       ])
 
-    {:ok, port}
+    {:ok, %{port: port, stats: initial_stats()}}
+  end
+
+  defp initial_stats() do
+    %{
+      uevents_received: 0,
+      uevents_dropped: 0,
+      modprobes_called: 0,
+      modaliases_queued: 0,
+      modaliases_dropped: 0,
+      modprobe_fork_failures: 0,
+      peak_queue_n: 0,
+      peak_queue_bytes: 0,
+      actions: %{
+        add: 0,
+        change: 0,
+        remove: 0,
+        move: 0,
+        bind: 0,
+        unbind: 0,
+        other: 0
+      }
+    }
   end
 
   @impl GenServer
-  def handle_info({port, {:data, message}}, port) do
-    case :erlang.binary_to_term(message) do
-      {:add, path, kvmap} ->
-        PropertyTable.put(NervesUEvent, path, kvmap)
-
-      {:bind, _path, _kvmap} ->
-        # Ignore device driver bind updates
-        :ok
-
-      {:change, path, kvmap} ->
-        PropertyTable.put(NervesUEvent, path, kvmap)
-
-      {:move, new_path, %{"devpath_old" => devpath_old}} ->
-        old_path = String.split(devpath_old, "/")
-        kvmap = PropertyTable.get(NervesUEvent, old_path)
-        PropertyTable.delete(NervesUEvent, old_path)
-        PropertyTable.put(NervesUEvent, new_path, kvmap)
-
-      {:remove, path, _kvmap} ->
-        PropertyTable.delete(NervesUEvent, path)
-
-      {:unbind, _path, _kvmap} ->
-        # Ignore device driver unbind updates
-        :ok
-
-      {other, path, kvmap} ->
-        Logger.error(
-          "Unexpected uevent reported: #{inspect(other)}, #{inspect(path)}, #{inspect(kvmap)}"
-        )
-    end
-
-    {:noreply, port}
+  def handle_call(:stats, _from, state) do
+    {:reply, state.stats, state}
   end
 
-  def handle_info(_, port), do: {:noreply, port}
+  @impl GenServer
+  def handle_info({port, {:data, message}}, %{port: port} = state) do
+    new_state =
+      case :erlang.binary_to_term(message) do
+        {:add, path, kvmap} ->
+          PropertyTable.put(NervesUEvent, path, kvmap)
+          state
+
+        {:bind, _path, _kvmap} ->
+          # Ignore device driver bind updates
+          state
+
+        {:change, path, kvmap} ->
+          PropertyTable.put(NervesUEvent, path, kvmap)
+          state
+
+        {:move, new_path, %{"devpath_old" => devpath_old}} ->
+          old_path = String.split(devpath_old, "/")
+          kvmap = PropertyTable.get(NervesUEvent, old_path)
+          PropertyTable.delete(NervesUEvent, old_path)
+          PropertyTable.put(NervesUEvent, new_path, kvmap)
+          state
+
+        {:remove, path, _kvmap} ->
+          PropertyTable.delete(NervesUEvent, path)
+          state
+
+        {:stats, stats} when is_map(stats) ->
+          %{state | stats: stats}
+
+        {:unbind, _path, _kvmap} ->
+          # Ignore device driver unbind updates
+          state
+
+        {other, path, kvmap} ->
+          Logger.error(
+            "Unexpected uevent reported: #{inspect(other)}, #{inspect(path)}, #{inspect(kvmap)}"
+          )
+
+          state
+      end
+
+    {:noreply, new_state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
 end


### PR DESCRIPTION
Stats only get reported after 5s of inactivity to avoid them delaying
bursty uevent periods. These stats are most important for identifying
issues where you think a device should exist, but doesn't. It's also
helpful for tuning so that the modprobes happen as quickly as possible
on boot.
