### PR TITLE
Raise and check KV property cap

### DIFF
--- a/c_src/uevent.c
+++ b/c_src/uevent.c
@@ -540,6 +540,19 @@ static int nl_uevent_process_one(struct mnl_socket *nl_uevent, char *resp)
 
         // We like lowercase keys
         str_tolower(str);
+
+        // Skip duplicate keys
+        // See https://www.mail-archive.com/acpi-bugzilla%40lists.sourceforge.net/msg51785.html
+        int duplicate = 0;
+        for (int i = 0; i < kvpairs_count; i++) {
+            if (strcmp(keys[i], str) == 0) {
+                duplicate = 1;
+                break;
+            }
+        }
+        if (duplicate)
+            continue;
+
         keys[kvpairs_count] = str;
 
         // The kernel wraps some values in literal double quotes — notably

--- a/c_src/uevent.c
+++ b/c_src/uevent.c
@@ -510,12 +510,17 @@ static int nl_uevent_process_one(struct mnl_socket *nl_uevent, char *resp)
         return 0;
     ei_encode_devpath(resp, &resp_index, str, &str);
 
-#define MAX_KV_PAIRS 16
+    // Most report <16 pairs. One battery had 20 properties after filtering.
+#define MAX_KV_PAIRS 64
     int kvpairs_count = 0;
     char *keys[MAX_KV_PAIRS];
     char *values[MAX_KV_PAIRS];
 
     for (; str < str_end; str += strlen(str) + 1) {
+        // Silently drop kv pairs rather than overflow.
+        if (kvpairs_count >= MAX_KV_PAIRS)
+            break;
+
         // Don't encode these keys in the map:
         //
         // ACTION: already delivered


### PR DESCRIPTION
This fixes an issue where a battery with 20 properties after filtering
caused `:erlang.binary_to_term/1` to raise. The check fixes the raise
and bumping the max count makes that battery work.

This also fixes a duplicate key issue.

Here's the `uevent` file:

```
$ cat /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00/device:41/PNP0C0A:00/power_supply/BAT1/uevent
DEVTYPE=power_supply
POWER_SUPPLY_NAME=BAT1
POWER_SUPPLY_TYPE=Battery
POWER_SUPPLY_STATUS=Discharging
POWER_SUPPLY_PRESENT=1
POWER_SUPPLY_TECHNOLOGY=Li-ion
POWER_SUPPLY_CYCLE_COUNT=22
POWER_SUPPLY_VOLTAGE_MIN_DESIGN=15480000
POWER_SUPPLY_VOLTAGE_NOW=17515000
POWER_SUPPLY_CURRENT_NOW=107000
POWER_SUPPLY_CHARGE_FULL_DESIGN=3915000
POWER_SUPPLY_CHARGE_FULL=4026000
POWER_SUPPLY_CHARGE_NOW=4026000
POWER_SUPPLY_CAPACITY=100
POWER_SUPPLY_CAPACITY_LEVEL=Normal
POWER_SUPPLY_TYPE=Battery
POWER_SUPPLY_MODEL_NAME=FRANGWA
POWER_SUPPLY_MANUFACTURER=NVT
POWER_SUPPLY_SERIAL_NUMBER=01D6
```

Here's more information: https://www.mail-archive.com/acpi-bugzilla%40lists.sourceforge.net/msg51785.html

Thanks to @gausby for finding this issue and confirming the fix works on his system.
