### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # NervesUEvent
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_uevent.svg "Hex version")](https://hex.pm/packages/nerves_uevent)
-[![API docs](https://img.shields.io/hexpm/v/nerves_uevent.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_uevent/NervesUEvent.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_uevent.svg?label=hexdocs "API docs")](https://nerves-uevent.hexdocs.pm/NervesUEvent.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/nerves_uevent/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/nerves_uevent/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_uevent)](https://api.reuse.software/info/github.com/nerves-project/nerves_uevent)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-uevent.hexdocs.pm/NervesUEvent.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>